### PR TITLE
Use elm/bytes internally

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -10,9 +10,7 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/bytes": "1.0.8 <= v < 2.0.0",
-        "elm/core": "1.0.2 <= v < 2.0.0",
-        "jxxcarlson/hex": "4.0.0 <= v < 5.0.0",
-        "zwilias/elm-utf-tools": "2.0.1 <= v < 3.0.0"
+        "elm/core": "1.0.2 <= v < 2.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.0.0 <= v < 2.0.0"

--- a/elm.json
+++ b/elm.json
@@ -9,6 +9,7 @@
     ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
+        "elm/bytes": "1.0.8 <= v < 2.0.0",
         "elm/core": "1.0.0 <= v < 2.0.0",
         "zwilias/elm-utf-tools": "2.0.0 <= v < 3.0.0"
     },

--- a/elm.json
+++ b/elm.json
@@ -10,8 +10,9 @@
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/bytes": "1.0.8 <= v < 2.0.0",
-        "elm/core": "1.0.0 <= v < 2.0.0",
-        "zwilias/elm-utf-tools": "2.0.0 <= v < 3.0.0"
+        "elm/core": "1.0.2 <= v < 2.0.0",
+        "jxxcarlson/hex": "4.0.0 <= v < 5.0.0",
+        "zwilias/elm-utf-tools": "2.0.1 <= v < 3.0.0"
     },
     "test-dependencies": {
         "elm-explorations/test": "1.0.0 <= v < 2.0.0"

--- a/src/MD5.elm
+++ b/src/MD5.elm
@@ -1,4 +1,4 @@
-module MD5 exposing (hex, bytes)
+module MD5 exposing (hex, byteValues)
 
 {-| This library allows you to compute MD5 message digests in Elm. It exposes a
 single function that takes any string and outputs a "fingerprint" containing 32
@@ -8,16 +8,24 @@ hexadecimal characters. More information about the MD5 algorithm can be found
 
 # Digest Functions
 
-@docs hex, bytes
+@docs hex, byteValues
 
 -}
 
 import Array exposing (Array)
 import Bitwise exposing (and, complement, or, shiftLeftBy, shiftRightBy, shiftRightZfBy)
-import Bytes exposing (Bytes)
+import Bytes exposing (Bytes, Endianness(..))
 import Bytes.Decode as Decode exposing (Decoder, Step(..))
 import Bytes.Encode as Encode
+import Hex.Convert
 import String.UTF8 as UTF8
+
+
+blockToString b16 b15 b14 b13 b12 b11 b10 b9 b8 b7 b6 b5 b4 b3 b2 b1 =
+    [ b16, b15, b14, b13, b12, b11, b10, b9, b8, b7, b6, b5, b4, b3, b2, b1 ]
+        |> List.reverse
+        |> List.map (Bitwise.shiftRightZfBy 0 >> toHex >> String.padLeft 8 '0')
+        |> String.join " "
 
 
 {-| Given a string of arbitrary length, returns a string of 32 hexadecimal
@@ -32,13 +40,14 @@ characters (a-f, 0-9) representing the 128-bit MD5 message digest.
 -}
 hex : String -> String
 hex s =
-    List.foldl (\b acc -> acc ++ String.padLeft 2 '0' (toHex b)) "" (bytes s)
+    -- List.foldl (\b acc -> acc ++ String.padLeft 2 '0' (toHex b)) "" (byteValues s)
+    fromString s
 
 
 {-| Given a string of arbitrary length, returns a list of integers representing
 the hash as a series of individual bytes.
 
-    bytes "hello world"
+    byteValues "hello world"
     --> [ 0x5e , 0xb6 , 0x3b , 0xbb
     --> , 0xe0 , 0x1e , 0xee , 0xd0
     --> , 0x93 , 0xcb , 0x22 , 0xbb
@@ -46,12 +55,13 @@ the hash as a series of individual bytes.
     --> ]
 
 -}
-bytes : String -> List Int
-bytes string =
-    let
-        { a, b, c, d } =
-            hash string
-    in
+byteValues : String -> List Int
+byteValues string =
+    toByteValues (hashBytes (Encode.encode (Encode.string string)) initialHashState)
+
+
+toByteValues : State -> List Int
+toByteValues { a, b, c, d } =
     [ and a 255
     , and (shiftRightZfBy 8 a) 255
     , and (shiftRightZfBy 16 a) 255
@@ -71,279 +81,296 @@ bytes string =
     ]
 
 
+fromBytes : Bytes -> String
+fromBytes bytes =
+    hashBytes bytes initialHashState
+        |> toByteValues
+        |> List.foldl (\b acc -> acc ++ String.padLeft 2 '0' (toHex b)) ""
+
+
+fromString : String -> String
+fromString string =
+    fromBytes (Encode.encode (Encode.string string))
+
+
 hex_ : List Int -> State -> State
-hex_ xs ({ a, b, c, d } as acc) =
+hex_ xs acc =
     case xs of
         [ x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15 ] ->
-            let
-                s11 =
-                    7
-
-                s12 =
-                    12
-
-                s13 =
-                    17
-
-                s14 =
-                    22
-
-                s21 =
-                    5
-
-                s22 =
-                    9
-
-                s23 =
-                    14
-
-                s24 =
-                    20
-
-                s31 =
-                    4
-
-                s32 =
-                    11
-
-                s33 =
-                    16
-
-                s34 =
-                    23
-
-                s41 =
-                    6
-
-                s42 =
-                    10
-
-                s43 =
-                    15
-
-                s44 =
-                    21
-
-                a00 =
-                    a
-
-                b00 =
-                    b
-
-                c00 =
-                    c
-
-                d00 =
-                    d
-
-                a01 =
-                    ff a00 b00 c00 d00 x0 s11 0xD76AA478
-
-                d01 =
-                    ff d00 a01 b00 c00 x1 s12 0xE8C7B756
-
-                c01 =
-                    ff c00 d01 a01 b00 x2 s13 0x242070DB
-
-                b01 =
-                    ff b00 c01 d01 a01 x3 s14 0xC1BDCEEE
-
-                a02 =
-                    ff a01 b01 c01 d01 x4 s11 0xF57C0FAF
-
-                d02 =
-                    ff d01 a02 b01 c01 x5 s12 0x4787C62A
-
-                c02 =
-                    ff c01 d02 a02 b01 x6 s13 0xA8304613
-
-                b02 =
-                    ff b01 c02 d02 a02 x7 s14 0xFD469501
-
-                a03 =
-                    ff a02 b02 c02 d02 x8 s11 0x698098D8
-
-                d03 =
-                    ff d02 a03 b02 c02 x9 s12 0x8B44F7AF
-
-                c03 =
-                    ff c02 d03 a03 b02 x10 s13 0xFFFF5BB1
-
-                b03 =
-                    ff b02 c03 d03 a03 x11 s14 0x895CD7BE
-
-                a04 =
-                    ff a03 b03 c03 d03 x12 s11 0x6B901122
-
-                d04 =
-                    ff d03 a04 b03 c03 x13 s12 0xFD987193
-
-                c04 =
-                    ff c03 d04 a04 b03 x14 s13 0xA679438E
-
-                b04 =
-                    ff b03 c04 d04 a04 x15 s14 0x49B40821
-
-                a05 =
-                    gg a04 b04 c04 d04 x1 s21 0xF61E2562
-
-                d05 =
-                    gg d04 a05 b04 c04 x6 s22 0xC040B340
-
-                c05 =
-                    gg c04 d05 a05 b04 x11 s23 0x265E5A51
-
-                b05 =
-                    gg b04 c05 d05 a05 x0 s24 0xE9B6C7AA
-
-                a06 =
-                    gg a05 b05 c05 d05 x5 s21 0xD62F105D
-
-                d06 =
-                    gg d05 a06 b05 c05 x10 s22 0x02441453
-
-                c06 =
-                    gg c05 d06 a06 b05 x15 s23 0xD8A1E681
-
-                b06 =
-                    gg b05 c06 d06 a06 x4 s24 0xE7D3FBC8
-
-                a07 =
-                    gg a06 b06 c06 d06 x9 s21 0x21E1CDE6
-
-                d07 =
-                    gg d06 a07 b06 c06 x14 s22 0xC33707D6
-
-                c07 =
-                    gg c06 d07 a07 b06 x3 s23 0xF4D50D87
-
-                b07 =
-                    gg b06 c07 d07 a07 x8 s24 0x455A14ED
-
-                a08 =
-                    gg a07 b07 c07 d07 x13 s21 0xA9E3E905
-
-                d08 =
-                    gg d07 a08 b07 c07 x2 s22 0xFCEFA3F8
-
-                c08 =
-                    gg c07 d08 a08 b07 x7 s23 0x676F02D9
-
-                b08 =
-                    gg b07 c08 d08 a08 x12 s24 0x8D2A4C8A
-
-                a09 =
-                    hh a08 b08 c08 d08 x5 s31 0xFFFA3942
-
-                d09 =
-                    hh d08 a09 b08 c08 x8 s32 0x8771F681
-
-                c09 =
-                    hh c08 d09 a09 b08 x11 s33 0x6D9D6122
-
-                b09 =
-                    hh b08 c09 d09 a09 x14 s34 0xFDE5380C
-
-                a10 =
-                    hh a09 b09 c09 d09 x1 s31 0xA4BEEA44
-
-                d10 =
-                    hh d09 a10 b09 c09 x4 s32 0x4BDECFA9
-
-                c10 =
-                    hh c09 d10 a10 b09 x7 s33 0xF6BB4B60
-
-                b10 =
-                    hh b09 c10 d10 a10 x10 s34 0xBEBFBC70
-
-                a11 =
-                    hh a10 b10 c10 d10 x13 s31 0x289B7EC6
-
-                d11 =
-                    hh d10 a11 b10 c10 x0 s32 0xEAA127FA
-
-                c11 =
-                    hh c10 d11 a11 b10 x3 s33 0xD4EF3085
-
-                b11 =
-                    hh b10 c11 d11 a11 x6 s34 0x04881D05
-
-                a12 =
-                    hh a11 b11 c11 d11 x9 s31 0xD9D4D039
-
-                d12 =
-                    hh d11 a12 b11 c11 x12 s32 0xE6DB99E5
-
-                c12 =
-                    hh c11 d12 a12 b11 x15 s33 0x1FA27CF8
-
-                b12 =
-                    hh b11 c12 d12 a12 x2 s34 0xC4AC5665
-
-                a13 =
-                    ii a12 b12 c12 d12 x0 s41 0xF4292244
-
-                d13 =
-                    ii d12 a13 b12 c12 x7 s42 0x432AFF97
-
-                c13 =
-                    ii c12 d13 a13 b12 x14 s43 0xAB9423A7
-
-                b13 =
-                    ii b12 c13 d13 a13 x5 s44 0xFC93A039
-
-                a14 =
-                    ii a13 b13 c13 d13 x12 s41 0x655B59C3
-
-                d14 =
-                    ii d13 a14 b13 c13 x3 s42 0x8F0CCC92
-
-                c14 =
-                    ii c13 d14 a14 b13 x10 s43 0xFFEFF47D
-
-                b14 =
-                    ii b13 c14 d14 a14 x1 s44 0x85845DD1
-
-                a15 =
-                    ii a14 b14 c14 d14 x8 s41 0x6FA87E4F
-
-                d15 =
-                    ii d14 a15 b14 c14 x15 s42 0xFE2CE6E0
-
-                c15 =
-                    ii c14 d15 a15 b14 x6 s43 0xA3014314
-
-                b15 =
-                    ii b14 c15 d15 a15 x13 s44 0x4E0811A1
-
-                a16 =
-                    ii a15 b15 c15 d15 x4 s41 0xF7537E82
-
-                d16 =
-                    ii d15 a16 b15 c15 x11 s42 0xBD3AF235
-
-                c16 =
-                    ii c15 d16 a16 b15 x2 s43 0x2AD7D2BB
-
-                b16 =
-                    ii b15 c16 d16 a16 x9 s44 0xEB86D391
-
-                a17 =
-                    addUnsigned a00 a16
-
-                b17 =
-                    addUnsigned b00 b16
-
-                c17 =
-                    addUnsigned c00 c16
-
-                d17 =
-                    addUnsigned d00 d16
-            in
-            { a = a17, b = b17, c = c17, d = d17 }
+            hex__ acc x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15
 
         _ ->
             acc
+
+
+hex__ ({ a, b, c, d } as acc) x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 =
+    let
+        -- _ = Debug.log "input block" (blockToString x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15)
+        s11 =
+            7
+
+        s12 =
+            12
+
+        s13 =
+            17
+
+        s14 =
+            22
+
+        s21 =
+            5
+
+        s22 =
+            9
+
+        s23 =
+            14
+
+        s24 =
+            20
+
+        s31 =
+            4
+
+        s32 =
+            11
+
+        s33 =
+            16
+
+        s34 =
+            23
+
+        s41 =
+            6
+
+        s42 =
+            10
+
+        s43 =
+            15
+
+        s44 =
+            21
+
+        a00 =
+            a
+
+        b00 =
+            b
+
+        c00 =
+            c
+
+        d00 =
+            d
+
+        a01 =
+            ff a00 b00 c00 d00 x0 s11 0xD76AA478
+
+        d01 =
+            ff d00 a01 b00 c00 x1 s12 0xE8C7B756
+
+        c01 =
+            ff c00 d01 a01 b00 x2 s13 0x242070DB
+
+        b01 =
+            ff b00 c01 d01 a01 x3 s14 0xC1BDCEEE
+
+        a02 =
+            ff a01 b01 c01 d01 x4 s11 0xF57C0FAF
+
+        d02 =
+            ff d01 a02 b01 c01 x5 s12 0x4787C62A
+
+        c02 =
+            ff c01 d02 a02 b01 x6 s13 0xA8304613
+
+        b02 =
+            ff b01 c02 d02 a02 x7 s14 0xFD469501
+
+        a03 =
+            ff a02 b02 c02 d02 x8 s11 0x698098D8
+
+        d03 =
+            ff d02 a03 b02 c02 x9 s12 0x8B44F7AF
+
+        c03 =
+            ff c02 d03 a03 b02 x10 s13 0xFFFF5BB1
+
+        b03 =
+            ff b02 c03 d03 a03 x11 s14 0x895CD7BE
+
+        a04 =
+            ff a03 b03 c03 d03 x12 s11 0x6B901122
+
+        d04 =
+            ff d03 a04 b03 c03 x13 s12 0xFD987193
+
+        c04 =
+            ff c03 d04 a04 b03 x14 s13 0xA679438E
+
+        b04 =
+            ff b03 c04 d04 a04 x15 s14 0x49B40821
+
+        a05 =
+            gg a04 b04 c04 d04 x1 s21 0xF61E2562
+
+        d05 =
+            gg d04 a05 b04 c04 x6 s22 0xC040B340
+
+        c05 =
+            gg c04 d05 a05 b04 x11 s23 0x265E5A51
+
+        b05 =
+            gg b04 c05 d05 a05 x0 s24 0xE9B6C7AA
+
+        a06 =
+            gg a05 b05 c05 d05 x5 s21 0xD62F105D
+
+        d06 =
+            gg d05 a06 b05 c05 x10 s22 0x02441453
+
+        c06 =
+            gg c05 d06 a06 b05 x15 s23 0xD8A1E681
+
+        b06 =
+            gg b05 c06 d06 a06 x4 s24 0xE7D3FBC8
+
+        a07 =
+            gg a06 b06 c06 d06 x9 s21 0x21E1CDE6
+
+        d07 =
+            gg d06 a07 b06 c06 x14 s22 0xC33707D6
+
+        c07 =
+            gg c06 d07 a07 b06 x3 s23 0xF4D50D87
+
+        b07 =
+            gg b06 c07 d07 a07 x8 s24 0x455A14ED
+
+        a08 =
+            gg a07 b07 c07 d07 x13 s21 0xA9E3E905
+
+        d08 =
+            gg d07 a08 b07 c07 x2 s22 0xFCEFA3F8
+
+        c08 =
+            gg c07 d08 a08 b07 x7 s23 0x676F02D9
+
+        b08 =
+            gg b07 c08 d08 a08 x12 s24 0x8D2A4C8A
+
+        a09 =
+            hh a08 b08 c08 d08 x5 s31 0xFFFA3942
+
+        d09 =
+            hh d08 a09 b08 c08 x8 s32 0x8771F681
+
+        c09 =
+            hh c08 d09 a09 b08 x11 s33 0x6D9D6122
+
+        b09 =
+            hh b08 c09 d09 a09 x14 s34 0xFDE5380C
+
+        a10 =
+            hh a09 b09 c09 d09 x1 s31 0xA4BEEA44
+
+        d10 =
+            hh d09 a10 b09 c09 x4 s32 0x4BDECFA9
+
+        c10 =
+            hh c09 d10 a10 b09 x7 s33 0xF6BB4B60
+
+        b10 =
+            hh b09 c10 d10 a10 x10 s34 0xBEBFBC70
+
+        a11 =
+            hh a10 b10 c10 d10 x13 s31 0x289B7EC6
+
+        d11 =
+            hh d10 a11 b10 c10 x0 s32 0xEAA127FA
+
+        c11 =
+            hh c10 d11 a11 b10 x3 s33 0xD4EF3085
+
+        b11 =
+            hh b10 c11 d11 a11 x6 s34 0x04881D05
+
+        a12 =
+            hh a11 b11 c11 d11 x9 s31 0xD9D4D039
+
+        d12 =
+            hh d11 a12 b11 c11 x12 s32 0xE6DB99E5
+
+        c12 =
+            hh c11 d12 a12 b11 x15 s33 0x1FA27CF8
+
+        b12 =
+            hh b11 c12 d12 a12 x2 s34 0xC4AC5665
+
+        a13 =
+            ii a12 b12 c12 d12 x0 s41 0xF4292244
+
+        d13 =
+            ii d12 a13 b12 c12 x7 s42 0x432AFF97
+
+        c13 =
+            ii c12 d13 a13 b12 x14 s43 0xAB9423A7
+
+        b13 =
+            ii b12 c13 d13 a13 x5 s44 0xFC93A039
+
+        a14 =
+            ii a13 b13 c13 d13 x12 s41 0x655B59C3
+
+        d14 =
+            ii d13 a14 b13 c13 x3 s42 0x8F0CCC92
+
+        c14 =
+            ii c13 d14 a14 b13 x10 s43 0xFFEFF47D
+
+        b14 =
+            ii b13 c14 d14 a14 x1 s44 0x85845DD1
+
+        a15 =
+            ii a14 b14 c14 d14 x8 s41 0x6FA87E4F
+
+        d15 =
+            ii d14 a15 b14 c14 x15 s42 0xFE2CE6E0
+
+        c15 =
+            ii c14 d15 a15 b14 x6 s43 0xA3014314
+
+        b15 =
+            ii b14 c15 d15 a15 x13 s44 0x4E0811A1
+
+        a16 =
+            ii a15 b15 c15 d15 x4 s41 0xF7537E82
+
+        d16 =
+            ii d15 a16 b15 c15 x11 s42 0xBD3AF235
+
+        c16 =
+            ii c15 d16 a16 b15 x2 s43 0x2AD7D2BB
+
+        b16 =
+            ii b15 c16 d16 a16 x9 s44 0xEB86D391
+
+        a17 =
+            addUnsigned a00 a16
+
+        b17 =
+            addUnsigned b00 b16
+
+        c17 =
+            addUnsigned c00 c16
+
+        d17 =
+            addUnsigned d00 d16
+    in
+    { a = a17, b = b17, c = c17, d = d17 }
 
 
 hash : String -> State
@@ -351,6 +378,98 @@ hash input =
     input
         |> UTF8.foldl consume ( initialHashState, ( 0, emptyWords ), 0 )
         |> finishUp
+
+
+padBuffer : Int -> Bytes -> Bytes
+padBuffer byteCount bytes =
+    let
+        finalBlockSize =
+            -- modBy 64 byteCount, but faster
+            Bitwise.and byteCount 0x3F
+
+        paddingSize =
+            -- I'm not totally sure where these numbers come from
+            -- the 4 is because we encode the length as u32, where u64 is expected
+            if finalBlockSize < 56 then
+                55 - finalBlockSize
+
+            else
+                119 - finalBlockSize
+
+        message =
+            Encode.encode
+                (Encode.sequence
+                    [ Encode.bytes bytes
+                    , Encode.unsignedInt8 0x80
+                    , Encode.sequence (List.repeat paddingSize (Encode.unsignedInt8 0))
+                    , Encode.unsignedInt32 LE (Bitwise.shiftLeftBy 3 byteCount)
+                    , Encode.unsignedInt32 LE 0
+                    ]
+                )
+    in
+    message
+
+
+hashBytes : Bytes -> State -> State
+hashBytes bytes state =
+    hashBytesHelp (Bytes.width bytes) True bytes state
+
+
+maxBufferSize : Int
+maxBufferSize =
+    2048 * 64
+
+
+hashBytesHelp : Int -> Bool -> Bytes -> State -> State
+hashBytesHelp fullSize isLast bytes state =
+    if Bytes.width bytes > maxBufferSize then
+        let
+            ( first, rest ) =
+                splitBytes maxBufferSize bytes
+        in
+        hashBytesHelp fullSize True rest (hashBytesHelp fullSize False first state)
+
+    else if isLast then
+        -- add padding bytes and length
+        hashChunks (padBuffer fullSize bytes) state
+
+    else
+        hashChunks bytes state
+
+
+hashChunks : Bytes -> State -> State
+hashChunks message state =
+    let
+        -- _ = Debug.log "message" (Hex.Convert.toString message)
+        numberOfChunks : Int
+        numberOfChunks =
+            Bytes.width message // 64
+
+        hashState : Decoder State
+        hashState =
+            iterate numberOfChunks reduceBytesMessage state
+    in
+    case Decode.decode hashState message of
+        Just newState ->
+            newState
+
+        Nothing ->
+            state
+
+
+u32 : Decoder Int
+u32 =
+    Decode.unsignedInt32 LE
+
+
+reduceBytesMessage : State -> Decoder State
+reduceBytesMessage state =
+    map16 (reduceChunk state) u32 u32 u32 u32 u32 u32 u32 u32 u32 u32 u32 u32 u32 u32 u32 u32
+
+
+reduceChunk state b16 b15 b14 b13 b12 b11 b10 b9 b8 b7 b6 b5 b4 b3 b2 b1 =
+    -- b16 b15 b14 b13 b12 b11 b10 b9 b8 b7 b6 b5 b4 b3 b2 b1
+    hex__ state b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16
 
 
 emptyWords : Array Int

--- a/src/MD5.elm
+++ b/src/MD5.elm
@@ -1,4 +1,4 @@
-module MD5 exposing (hex, byteValues)
+module MD5 exposing (hex, byteValues, fromBytes)
 
 {-| This library allows you to compute MD5 message digests in Elm. It exposes a
 single function that takes any string and outputs a "fingerprint" containing 32
@@ -8,7 +8,7 @@ hexadecimal characters. More information about the MD5 algorithm can be found
 
 # Digest Functions
 
-@docs hex, byteValues
+@docs hex, byteValues, fromBytes
 
 -}
 
@@ -459,57 +459,46 @@ addUnsigned x y =
     (x + y) |> Bitwise.and 0xFFFFFFFF
 
 
-f : Int -> Int -> Int -> Int
-f x y z =
-    Bitwise.xor y z
-        |> Bitwise.and x
-        |> Bitwise.xor z
-
-
-g : Int -> Int -> Int -> Int
-g x y z =
-    Bitwise.xor x y
-        |> Bitwise.and z
-        |> Bitwise.xor y
-
-
-h : Int -> Int -> Int -> Int
-h x y z =
-    Bitwise.xor x y |> Bitwise.xor z
-
-
-i : Int -> Int -> Int -> Int
-i x y z =
-    Bitwise.xor y (or x (complement z))
-
-
 ff : Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int
 ff a b c d x s ac =
-    cmn f a b c d x s ac
+    let
+        f =
+            Bitwise.xor c d
+                |> Bitwise.and b
+                |> Bitwise.xor d
+    in
+    rotateLeft s (f + x + ac + a) + b
 
 
 gg : Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int
 gg a b c d x s ac =
-    cmn g a b c d x s ac
+    let
+        g =
+            Bitwise.xor b c
+                |> Bitwise.and d
+                |> Bitwise.xor c
+    in
+    rotateLeft s (g + x + ac + a) + b
 
 
 hh : Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int
 hh a b c d x s ac =
-    cmn h a b c d x s ac
+    let
+        h =
+            Bitwise.xor b c |> Bitwise.xor d
+    in
+    rotateLeft s (h + x + ac + a) + b
 
 
 ii : Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int
 ii a b c d x s ac =
-    cmn i a b c d x s ac
-
-
-cmn : (Int -> Int -> Int -> Int) -> Int -> Int -> Int -> Int -> Int -> Int -> Int -> Int
-cmn fun a b c d x s ac =
-    addUnsigned (fun b c d) x
-        |> addUnsigned ac
-        |> addUnsigned a
-        |> rotateLeft s
-        |> addUnsigned b
+    let
+        i =
+            Bitwise.xor c (or b (complement d))
+                -- complement can flip the sign. Force unsigned
+                |> Bitwise.shiftRightZfBy 0
+    in
+    rotateLeft s (i + x + ac + a) + b
 
 
 

--- a/src/MD5.elm
+++ b/src/MD5.elm
@@ -85,7 +85,7 @@ fromString string =
     fromBytes (Encode.encode (Encode.string string))
 
 
-reduceChunk ({ a, b, c, d } as acc) x15 x14 x13 x12 x11 x10 x9 x8 x7 x6 x5 x4 x3 x2 x1 x0 =
+reduceChunk ({ a, b, c, d } as acc) x0 x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 =
     let
         s11 =
             7
@@ -502,12 +502,21 @@ map16 :
     -> Decoder b15
     -> Decoder b16
     -> Decoder result
-map16 function b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 =
-    Decode.succeed function
-        |> Decode.map5 (\a b c d e -> e d c b a) b4 b3 b2 b1
-        |> Decode.map5 (\a b c d e -> e d c b a) b8 b7 b6 b5
-        |> Decode.map5 (\a b c d e -> e d c b a) b12 b11 b10 b9
-        |> Decode.map5 (\a b c d e -> e d c b a) b16 b15 b14 b13
+map16 f b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 =
+    let
+        d1 =
+            Decode.map4 (\a b c d -> f a b c d) b1 b2 b3 b4
+
+        d2 =
+            Decode.map5 (\h a b c d -> h a b c d) d1 b5 b6 b7 b8
+
+        d3 =
+            Decode.map5 (\h a b c d -> h a b c d) d2 b9 b10 b11 b12
+
+        d4 =
+            Decode.map5 (\h a b c d -> h a b c d) d3 b13 b14 b15 b16
+    in
+    d4
 
 
 {-| Iterate a decoder `n` times

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -20,6 +20,7 @@ other =
         , test "latin1" "38e3f1e10c0b5072c874a72c3c6493d8" "æ ø å ñ"
         , test "unicode" "2adb08ac813a93665950fe9203faca10" "€ ♝ ♧ ☐"
         , test "newlines" "e1c06d85ae7b8b032bef47e42e4c08f9" "\n\n"
+        , test "large input" "7707d6ae4e027c70eea2a935c2296f21" (String.repeat 1000000 "a")
         ]
 
 


### PR DESCRIPTION
This PR adds `elm/bytes` support

It is very messy, this is just a proof of concept. It's your package and your api, so I haven't changed that for now. Let's discuss what the api should look like, and if the business logic should be optimized further

A  higher version of core is needed for both elm/bytes and elm-test to work. 

Weirdly, this md5 seems to go backward. I guess that was more efficient with the folds? anyhow, changing the encoding from big-endian to little-endian just makes that work. No need to touch the logic at all. 

For an input of 1kb, my version is twice as fast. It takes ~300ms to hash a 3Mb file. Most of the remaining time is spent in arithmetic, as expected. I think quite a bit could be improved by inlining functions, in particular unsigned addition. The compiler inlines bitwise operators, the overhead of a function call really seems to matter here.  

I think I saw somewhere that you also consider the bundle size for this package. I'm not sure how that is affected by this change. 

